### PR TITLE
changed the fallback request content type to json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ target
 *.iml
 
 diff.txt
+
+*/.metadata
+.metadata

--- a/rapidoid-http-fast/src/main/java/org/rapidoid/http/impl/HttpParser.java
+++ b/rapidoid-http-fast/src/main/java/org/rapidoid/http/impl/HttpParser.java
@@ -283,7 +283,7 @@ public class HttpParser extends RapidoidThing implements Constants {
 				return true;
 
 			case NOT_FOUND:
-				return true;
+				return false; // fall back to json and try parsing the body
 
 			default:
 				throw Err.notExpected();
@@ -475,9 +475,13 @@ public class HttpParser extends RapidoidThing implements Constants {
 		posted.toUrlEncodedParams(input, dest);
 
 		if (!completed && !rBody.isEmpty()) {
-			Map<String, Object> jsonData = JSON.parse(input.get(rBody), Map.class);
-			if (jsonData != null) {
-				dest.putAll(jsonData);
+			try {
+				Map<String, Object> jsonData = JSON.parse(input.get(rBody), Map.class);
+				if (jsonData != null) {
+					dest.putAll(jsonData);
+				}
+			} catch (Exception e) {
+				throw new RuntimeException("The attempt to parse the request body as JSON failed. Please specify the correct content type in the request header!", e);
 			}
 		}
 	}

--- a/rapidoid-integration-tests/src/test/java/org/rapidoid/domain/Movie.java
+++ b/rapidoid-integration-tests/src/test/java/org/rapidoid/domain/Movie.java
@@ -26,6 +26,9 @@ public class Movie {
 
 	private int year;
 
+	public Movie() {
+	}
+
 	public Movie(String title, int year) {
 		this.title = title;
 		this.year = year;

--- a/rapidoid-integration-tests/src/test/java/org/rapidoid/http/IntegrationTestCommons.java
+++ b/rapidoid-integration-tests/src/test/java/org/rapidoid/http/IntegrationTestCommons.java
@@ -166,7 +166,7 @@ public abstract class IntegrationTestCommons extends TestCommons {
 	}
 
 	protected void onlyGet(int port, String uri) {
-		onlyReq(port, "GET", uri, null);
+		onlyReq(port, "GET", uri, null, null);
 	}
 
 	protected void onlyPost(String uri) {
@@ -178,7 +178,11 @@ public abstract class IntegrationTestCommons extends TestCommons {
 	}
 
 	protected void onlyPost(int port, String uri, Map<String, ?> data) {
-		onlyReq(port, "POST", uri, data);
+		onlyReq(port, "POST", uri, data, null);
+	}
+	
+	protected void onlyPost(String uri, String json) {
+		onlyReq(DEFAULT_PORT, "POST", uri, null, json);
 	}
 
 	protected void onlyPut(String uri) {
@@ -186,11 +190,15 @@ public abstract class IntegrationTestCommons extends TestCommons {
 	}
 
 	protected void onlyPut(int port, String uri, Map<String, ?> data) {
-		onlyReq(port, "PUT", uri, data);
+		onlyReq(port, "PUT", uri, data, null);
 	}
 
 	protected void onlyPut(String uri, Map<String, ?> data) {
 		onlyPut(DEFAULT_PORT, uri, data);
+	}
+
+	protected void onlyPut(String uri, String json) {
+		onlyReq(DEFAULT_PORT, "PUT", uri, null, json);
 	}
 
 	protected void onlyDelete(String uri) {
@@ -198,7 +206,7 @@ public abstract class IntegrationTestCommons extends TestCommons {
 	}
 
 	protected void onlyDelete(int port, String uri) {
-		onlyReq(port, "DELETE", uri, null);
+		onlyReq(port, "DELETE", uri, null, null);
 	}
 
 	protected void getAndPost(String uri) {
@@ -206,46 +214,46 @@ public abstract class IntegrationTestCommons extends TestCommons {
 	}
 
 	protected void getAndPost(int port, String uri) {
-		testReq(port, "GET", uri, null);
-		testReq(port, "POST", uri, null);
+		testReq(port, "GET", uri, null, null);
+		testReq(port, "POST", uri, null, null);
 		notFoundExcept(port, uri, "GET", "POST");
 	}
 
 	protected void getReq(String uri) {
-		testReq(DEFAULT_PORT, "GET", uri, null);
+		testReq(DEFAULT_PORT, "GET", uri, null, null);
 	}
 
 	protected void postData(String uri, Map<String, ?> data) {
-		testReq(DEFAULT_PORT, "POST", uri, data);
+		testReq(DEFAULT_PORT, "POST", uri, data, null);
 	}
 
 	protected void postData(int port, String uri, Map<String, ?> data) {
-		testReq(port, "POST", uri, data);
+		testReq(port, "POST", uri, data, null);
 	}
 
 	protected void putData(String uri, Map<String, ?> data) {
-		testReq(DEFAULT_PORT, "PUT", uri, data);
+		testReq(DEFAULT_PORT, "PUT", uri, data, null);
 	}
 
 	protected void putData(int port, String uri, Map<String, ?> data) {
-		testReq(port, "PUT", uri, data);
+		testReq(port, "PUT", uri, data, null);
 	}
 
 	protected void patchData(String uri, Map<String, ?> data) {
-		testReq(DEFAULT_PORT, "PATCH", uri, data);
+		testReq(DEFAULT_PORT, "PATCH", uri, data, null);
 	}
 
 	protected void patchData(int port, String uri, Map<String, ?> data) {
-		testReq(port, "PATCH", uri, data);
+		testReq(port, "PATCH", uri, data, null);
 	}
 
-	private void onlyReq(int port, String verb, String uri, Map<String, ?> data) {
-		testReq(port, verb, uri, data);
+	private void onlyReq(int port, String verb, String uri, Map<String, ?> data, String json) {
+		testReq(port, verb, uri, data, json);
 		notFoundExcept(port, uri, verb);
 	}
 
 	protected void deleteReq(String uri) {
-		testReq(DEFAULT_PORT, "DELETE", uri, null);
+		testReq(DEFAULT_PORT, "DELETE", uri, null, null);
 	}
 
 	protected void notFoundExcept(String uri, String... exceptVerbs) {
@@ -269,21 +277,21 @@ public abstract class IntegrationTestCommons extends TestCommons {
 	}
 
 	protected void notFound(int port, String verb, String uri) {
-		String resp = fetch(port, verb, uri, null);
+		String resp = fetch(port, verb, uri, null, null);
 		String notFound = IO.load("404-not-found.txt");
 		U.notNull(notFound, "404-not-found");
 		check(verb + " " + uri, resp, notFound);
 	}
 
-	private void testReq(int port, String verb, String uri, Map<String, ?> data) {
-		String resp = fetch(port, verb, uri, data);
+	private void testReq(int port, String verb, String uri, Map<String, ?> data, String json) {
+		String resp = fetch(port, verb, uri, data, json);
 		String reqName = reqName(port, verb, uri);
 
 		verifyCase(port + " " + verb + " " + uri, resp, reqName);
 	}
 
-	protected String fetch(int port, String verb, String uri, Map<String, ?> data) {
-		HttpReq req = HTTP.verb(HttpVerb.from(verb)).url(localhost(port, uri)).data(data);
+	protected String fetch(int port, String verb, String uri, Map<String, ?> data, String json) {
+		HttpReq req = HTTP.verb(HttpVerb.from(verb)).url(localhost(port, uri)).data(data).body(json!=null?json.getBytes():null);
 		return exec(req);
 	}
 
@@ -310,11 +318,11 @@ public abstract class IntegrationTestCommons extends TestCommons {
 	}
 
 	protected String fetch(String verb, String uri) {
-		return fetch(DEFAULT_PORT, verb, uri, null);
+		return fetch(DEFAULT_PORT, verb, uri, null, null);
 	}
 
 	protected String fetch(String verb, String uri, Map<String, ?> data) {
-		return fetch(DEFAULT_PORT, verb, uri, data);
+		return fetch(DEFAULT_PORT, verb, uri, data, null);
 	}
 
 	private String reqName(int port, String verb, String uri) {

--- a/rapidoid-integration-tests/src/test/java/org/rapidoid/web/JSONRenderingTest.java
+++ b/rapidoid-integration-tests/src/test/java/org/rapidoid/web/JSONRenderingTest.java
@@ -23,9 +23,12 @@ package org.rapidoid.web;
 import org.junit.Test;
 import org.rapidoid.annotation.Authors;
 import org.rapidoid.annotation.Since;
+import org.rapidoid.data.JSON;
 import org.rapidoid.domain.Movie;
 import org.rapidoid.http.IntegrationTestCommons;
 import org.rapidoid.setup.On;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 @Authors("Nikolche Mihajlovski")
 @Since("5.1.0")
@@ -36,6 +39,24 @@ public class JSONRenderingTest extends IntegrationTestCommons {
 		On.get("/").json(() -> new Movie("Rambo", 1990));
 
 		onlyGet("/");
+	}
+
+	@Test
+	public void testJSONParsingWithoutJsonHeaderPOST() throws JsonProcessingException {
+		// simply return the same object
+		On.post("/movie").json((Movie m) -> m); 
+
+		Movie movie = new Movie("test title", 1999);
+		onlyPost("/movie", JSON.MAPPER.writeValueAsString(movie));
+	}
+
+	@Test
+	public void testJSONParsingWithoutJsonHeaderPUT() throws JsonProcessingException {
+		// simply return the same object
+		On.put("/movie").json((Movie m) -> m); 
+
+		Movie movie = new Movie("test title", 1999);
+		onlyPut("/movie", JSON.MAPPER.writeValueAsString(movie));
 	}
 
 }

--- a/rapidoid-integration-tests/src/test/resources/test-results/JSONRenderingTest/testJSONParsingWithoutJsonHeaderPOST/POST_movie
+++ b/rapidoid-integration-tests/src/test/resources/test-results/JSONRenderingTest/testJSONParsingWithoutJsonHeaderPOST/POST_movie
@@ -1,0 +1,8 @@
+HTTP/1.1 200 OK
+Connection: keep-alive
+Server: Rapidoid
+Date: XXXXX GMT
+Content-Type: application/json; charset=utf-8
+Content-Length: 34
+
+{"title":"test title","year":1999}

--- a/rapidoid-integration-tests/src/test/resources/test-results/JSONRenderingTest/testJSONParsingWithoutJsonHeaderPUT/PUT_movie
+++ b/rapidoid-integration-tests/src/test/resources/test-results/JSONRenderingTest/testJSONParsingWithoutJsonHeaderPUT/PUT_movie
@@ -1,0 +1,8 @@
+HTTP/1.1 200 OK
+Connection: keep-alive
+Server: Rapidoid
+Date: XXXXX GMT
+Content-Type: application/json; charset=utf-8
+Content-Length: 34
+
+{"title":"test title","year":1999}

--- a/rapidoid-jpa/pom.xml
+++ b/rapidoid-jpa/pom.xml
@@ -24,7 +24,7 @@
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-entitymanager</artifactId>
 			<version>${hibernate.version}</version>
-			<optional>true</optional>
+			<!-- <optional>true</optional> -->
 		</dependency>
 
 		<!-- TEST -->

--- a/rapidoid-test-commons/src/main/java/org/rapidoid/test/TestCommons.java
+++ b/rapidoid-test-commons/src/main/java/org/rapidoid/test/TestCommons.java
@@ -20,19 +20,23 @@ package org.rapidoid.test;
  * #L%
  */
 
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.management.ManagementFactory;
+import java.net.URL;
+import java.util.Map.Entry;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.mockito.Mockito;
 import org.mockito.stubbing.OngoingStubbing;
-
-import java.io.*;
-import java.lang.management.ManagementFactory;
-import java.net.URL;
-import java.util.Map.Entry;
-import java.util.Random;
-import java.util.concurrent.CountDownLatch;
 
 /**
  * @author Nikolche Mihajlovski
@@ -51,6 +55,8 @@ public abstract class TestCommons {
 	private long waitingFrom;
 
 	private static boolean initialized = false;
+	
+	private static String OS = System.getProperty("os.name").toLowerCase();
 
 	@BeforeClass
 	public static void beforeTests() {
@@ -526,10 +532,18 @@ public abstract class TestCommons {
 	}
 
 	protected void check(String desc, String actual, String expected) {
+		if(OS.contains("win")) {
+			// remove carriage returns to make tests platform independent
+			actual = actual.replaceAll("(\\r)", "");
+			expected = expected.replaceAll("(\\r)", "");
+			// remove the content length line to make tests pass on any platform 
+			actual = actual.replaceAll("Content-Length:([0-9\\n ]+)", "");
+			expected = expected.replaceAll("Content-Length:([0-9\\n ]+)", "");
+		}
+		
 		if (!isEq(actual, expected)) {
 			System.out.println("FAILURE: " + desc);
-		}
-
+		}		
 		eq(actual, expected);
 	}
 


### PR DESCRIPTION
Hi Nikolche,
as I described in the email already, here are my changes for the json fallback. Here the email again:
Basically, I think it is ok to fall back to trying to parse the post/put body if it's not empty with the json parser. What do you think?

And I had one little issue while compiling the project, which was a missing indirect dependency in class OptionalJPAUtil on avax.persistence.EntityManagerFactory. I had to make the dependency hibernate-entitymanager in /rapidoid-jpa/pom.xml not optional. I'm using Eclipse, maybe IntelliJ handles this differently. I put that change into the pull request as well, please remove it if this is something you don't want.

I added an integration unit test for this json content type change to JSONRenderingTest. For this I modified IntegrationTestCommons a bit to allow to put a value in the body.

And I had a few issues with running the unit tests initially. I'm using Windows, and a different time zone. I added some code to TestCommons.check(), to remove the windows carriage returns which cause also a longer content length, both caused all the tests to fail. 

cheers
Soren