### PR TITLE
Fix UrlDecode RuntimeException

### DIFF
--- a/rapidoid-commons/src/main/java/org/rapidoid/util/Msc.java
+++ b/rapidoid-commons/src/main/java/org/rapidoid/util/Msc.java
@@ -313,6 +313,9 @@ public class Msc extends RapidoidThing implements Constants {
 			return URLEncoder.encode(value, "UTF-8");
 		} catch (UnsupportedEncodingException e) {
 			throw U.rte(e);
+		} catch (IllegalArgumentException e){
+			// TODO : This Exception Maybe Needs A Better Resolution ( Though this one keeps things going and not blowing )
+			return value;
 		}
 	}
 
@@ -321,6 +324,9 @@ public class Msc extends RapidoidThing implements Constants {
 			return URLDecoder.decode(value, "UTF-8");
 		} catch (UnsupportedEncodingException e) {
 			throw U.rte(e);
+		} catch (IllegalArgumentException e) {
+			// TODO : This Exception Maybe Needs A Better Resolution ( Though this one keeps things going and not blowing )
+			return value;
 		}
 	}
 

--- a/rapidoid-integration-tests/src/test/java/org/rapidoid/httpfast/UrlDecode.java
+++ b/rapidoid-integration-tests/src/test/java/org/rapidoid/httpfast/UrlDecode.java
@@ -1,0 +1,23 @@
+package org.rapidoid.httpfast;
+
+import org.rapidoid.http.Req;
+import org.rapidoid.http.ReqHandler;
+import org.rapidoid.setup.On;
+
+/**
+ * Created by qlyine on 6/8/16.
+ */
+public class UrlDecode {
+    public static void main(String[] args) {
+        On.address("0.0.0.0").port(8080);
+        On.get("/ping").serve(new ReqHandler() {
+            @Override
+            public Object execute(Req req) throws Exception {
+                System.out.println(req);
+                System.out.println(req.uri());
+                System.out.println(req.params());
+                return req.params();
+            }
+        });
+    }
+}


### PR DESCRIPTION
There are times one must accept weird URLs, that were not encoded, as they should have been.

If one does something like :

` curl -i "localhost:8080/ping?a=[%A%]" `

With the following simple code :

```
    public static void main(String[] args) {
        On.address("0.0.0.0").port(8080);
        On.get("/ping").serve(new ReqHandler() {
            @Override
            public Object execute(Req req) throws Exception {
                System.out.println(req);
                System.out.println(req.uri());
                System.out.println(req.params());
                return req.params();
            }
        });
    }

```
The server would blow up giving an empty reply to the client.
Whereas now it will just accept the param "[%A%]", for instances, and continue the flow. 

Best Regards,