### PR TITLE
Make the expiration thread a daemon thread

### DIFF
--- a/rapidoid-commons/src/main/java/org/rapidoid/expire/ExpirationCrawlerThread.java
+++ b/rapidoid-commons/src/main/java/org/rapidoid/expire/ExpirationCrawlerThread.java
@@ -42,6 +42,7 @@ public class ExpirationCrawlerThread extends RapidoidThread {
 		super(name);
 		this.resolution = resolution;
 		setPriority(Thread.MIN_PRIORITY);
+		setDaemon(true);
 	}
 
 	public void register(Iterable<? extends Expiring> collection) {


### PR DESCRIPTION
I might be missing something, but it seems to me that the expiration thread should be a daemon.

Right now, it is difficult for my application to go through an orderly shutdown because the `executorN` threads survive a call to `shutdown` on the `Setup` object, and because this thread survives. The former I can get around by calling `shutdown` on the global pool (although this is not an ideal solution if I have several `Setup` instances), but the latter thread I cannot shut down.