### PR TITLE
Adding shebang to sync.sh

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # add the main Rapidoid repository as upstream
 git remote add upstream https://github.com/rapidoid/rapidoid.git
 


### PR DESCRIPTION
sync.sh can be invoked ./synch.sh on any Unix-like clone operating system (Solaris, Linux, *BSD)