### PR TITLE
[low-level HTTP] a way to use a part of byte[] as a response body

### DIFF
--- a/rapidoid-http-fast/src/main/java/org/rapidoid/http/AbstractHttpServer.java
+++ b/rapidoid-http-fast/src/main/java/org/rapidoid/http/AbstractHttpServer.java
@@ -155,14 +155,18 @@ public abstract class AbstractHttpServer extends RapidoidThing implements Protoc
 		ctx.write(contentType.getBytes());
 		ctx.write(CR_LF);
 	}
-
+	
 	protected void writeBody(Channel ctx, byte[] body, MediaType contentType) {
+		writeBody(ctx, body, 0, body.length, contentType);
+	}
+
+	protected void writeBody(Channel ctx, byte[] body, int offset, int length, MediaType contentType) {
 		writeContentTypeHeader(ctx, contentType);
 		HttpIO.INSTANCE.writeContentLengthHeader(ctx, body.length);
 
 		ctx.write(CR_LF);
 
-		ctx.write(body);
+		ctx.write(body, offset, length);
 	}
 
 	protected void writeJsonBody(MaybeReq req, Channel ctx, Object value) {
@@ -181,10 +185,14 @@ public abstract class AbstractHttpServer extends RapidoidThing implements Protoc
 		writeJsonBody(req, ctx, value);
 		return HttpStatus.DONE;
 	}
-
+	
 	protected HttpStatus ok(Channel ctx, boolean isKeepAlive, byte[] body, MediaType contentType) {
+		return ok(ctx, isKeepAlive, body, 0, body.length, contentType);
+	}
+
+	protected HttpStatus ok(Channel ctx, boolean isKeepAlive, byte[] body, int offset, int length, MediaType contentType) {
 		startResponse(ctx, isKeepAlive);
-		writeBody(ctx, body, contentType);
+		writeBody(ctx, body, offset, length, contentType);
 		return HttpStatus.DONE;
 	}
 


### PR DESCRIPTION
Added `ok(Channel, boolean, byte[], int offset, int length, MediaType)` and `writeBody(Channel, byte[], int offset, int length, MediaType)` methods, so one could send a part of byte array (buffer) as a response body.