### PR TITLE
Support for alternative Hibernate config file

### DIFF
--- a/rapidoid-jpa/pom.xml
+++ b/rapidoid-jpa/pom.xml
@@ -41,21 +41,15 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-			<version>${mysql-connector.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<version>${h2.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.hsqldb</groupId>
-			<artifactId>hsqldb</artifactId>
-			<version>${hsqldb.version}</version>
+			<groupId>com.zaxxer</groupId>
+			<artifactId>HikariCP</artifactId>
+			<version>${hikari.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/rapidoid-jpa/src/main/java/org/rapidoid/jpa/EMFUtil.java
+++ b/rapidoid-jpa/src/main/java/org/rapidoid/jpa/EMFUtil.java
@@ -54,7 +54,7 @@ public class EMFUtil extends RapidoidThing {
 
 		return entityTypes;
 	}
-
+	
 	public static Properties hibernateProperties() {
 		return Conf.HIBERNATE.toProperties();
 	}

--- a/rapidoid-jpa/src/main/java/org/rapidoid/jpa/impl/CustomHibernatePersistenceProvider.java
+++ b/rapidoid-jpa/src/main/java/org/rapidoid/jpa/impl/CustomHibernatePersistenceProvider.java
@@ -56,9 +56,8 @@ public class CustomHibernatePersistenceProvider extends HibernatePersistenceProv
 
 		PersistenceUnitInfo info = new RapidoidPersistenceUnitInfo(persistenceUnitName, dataSource, providedClassLoader);
 		PersistenceUnitInfoDescriptor persistenceUnit = new PersistenceUnitInfoDescriptor(info);
-		final Map integration = wrap(properties);
 
-		return emfBuilder(persistenceUnit, integration, providedClassLoader);
+		return emfBuilder(persistenceUnit, properties, providedClassLoader);
 	}
 
 	private EntityManagerFactoryBuilder emfBuilder(PersistenceUnitDescriptor persistenceUnitDescriptor, Map integration, ClassLoader cl) {

--- a/rapidoid-jpa/src/test/java/org/rapidoid/jpa/impl/CustomHibernatePersistenceProviderTest.java
+++ b/rapidoid-jpa/src/test/java/org/rapidoid/jpa/impl/CustomHibernatePersistenceProviderTest.java
@@ -1,0 +1,22 @@
+package org.rapidoid.jpa.impl;
+
+import org.hibernate.jpa.boot.spi.EntityManagerFactoryBuilder;
+import org.junit.Test;
+import org.rapidoid.jdbc.JDBC;
+import org.rapidoid.jdbc.JdbcClient;
+import org.rapidoid.u.U;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertNotNull;
+
+public class CustomHibernatePersistenceProviderTest {
+    @Test
+    public void testAlternativeHibernateConfigFile() {
+        JdbcClient h2 = JDBC.h2("test").init();
+        CustomHibernatePersistenceProvider provider = new CustomHibernatePersistenceProvider(h2.bootstrapDatasource());
+        Map props = U.map("hibernate.ejb.cfgfile", "hibernate.xml");
+        EntityManagerFactoryBuilder emfBuilder = provider.getEntityManagerFactoryBuilderOrNull("test", props, this.getClass().getClassLoader());
+        assertNotNull(emfBuilder);
+    }
+}

--- a/rapidoid-jpa/src/test/resources/hibernate.xml
+++ b/rapidoid-jpa/src/test/resources/hibernate.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!DOCTYPE hibernate-configuration PUBLIC
+        "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+
+<hibernate-configuration>
+    <session-factory>
+
+    </session-factory>
+</hibernate-configuration>


### PR DESCRIPTION
**Version used with the the bug**

5.5.0

**Description of the bug**

When using the hibernate property `hibernate.ejb.cfgfile`, hibernate is throwing an exception `UnsupportedOperationException`.

```
java.lang.UnsupportedOperationException
	at java.util.Collections$UnmodifiableMap.remove(Collections.java:1460)
	at org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl.mergePropertySources(EntityManagerFactoryBuilderImpl.java:557)
	at org.hibernate.jpa.boot.internal.EntityManagerFactoryBuilderImpl.<init>(EntityManagerFactoryBuilderImpl.java:214)
	at org.hibernate.jpa.boot.spi.Bootstrap.getEntityManagerFactoryBuilder(Bootstrap.java:51)
	at org.hibernate.jpa.HibernatePersistenceProvider.getEntityManagerFactoryBuilder(HibernatePersistenceProvider.java:182)
	at org.rapidoid.jpa.impl.CustomHibernatePersistenceProvider.emfBuilder(CustomHibernatePersistenceProvider.java:65)
	at org.rapidoid.jpa.impl.CustomHibernatePersistenceProvider.getEntityManagerFactoryBuilderOrNull(CustomHibernatePersistenceProvider.java:60)
	at org.rapidoid.jpa.impl.CustomHibernatePersistenceProviderTest.testAlternativeHibernateConfigFile(CustomHibernatePersistenceProviderTest.java:19)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:51)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:237)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:147)
```

**Fix**

Instead of using an immutable map in the class `CustomHibernatePersistenceProvider`, I keep using the mutable Properties instance.

