### PR TITLE
Fix condition for updating CURR_DATE_BYTES

### DIFF
--- a/rapidoid-commons/src/main/java/org/rapidoid/commons/Dates.java
+++ b/rapidoid-commons/src/main/java/org/rapidoid/commons/Dates.java
@@ -50,7 +50,7 @@ public class Dates extends RapidoidThing {
 		long time = System.currentTimeMillis();
 
 		// avoid synchronization for better performance
-		if (time > updateCurrDateAfter) {
+		if (time >= updateCurrDateAfter) {
 
 			// RFC 1123 date-time format, e.g. Sun, 07 Sep 2014 00:17:29 GMT
 			DateFormat dateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.ROOT);
@@ -60,7 +60,7 @@ public class Dates extends RapidoidThing {
 			date.setTime(time);
 
 			CURR_DATE_BYTES = dateFormat.format(date).getBytes();
-			updateCurrDateAfter = time + 1000;
+			updateCurrDateAfter = time - (time % 1000) + 1000;
 		}
 
 		return CURR_DATE_BYTES;


### PR DESCRIPTION
The original code

```
case 1

first time:
time                = 2014-09-07T00:17:29
updateCurrDateAfter = 2014-09-07T00:17:30
CURR_DATE_BYTES     = Sun, 07 Sep 2014 00:17:29 GMT

next time:
time                = 2014-09-07T00:17:30
updateCurrDateAfter = 2014-09-07T00:17:30
CURR_DATE_BYTES     = Sun, 07 Sep 2014 00:17:29 GMT <- wrong!
          should be   Sun, 07 Sep 2014 00:17:30 GMT

case 2

first time:
time                = 2014-09-07T00:17:29.999
updateCurrDateAfter = 2014-09-07T00:17:30.999
CURR_DATE_BYTES     = Sun, 07 Sep 2014 00:17:29 GMT

next time:
time                = 2014-09-07T00:17:30.000
updateCurrDateAfter = 2014-09-07T00:17:30.999
CURR_DATE_BYTES     = Sun, 07 Sep 2014 00:17:29 GMT <- wrong!
          should be   Sun, 07 Sep 2014 00:17:30 GMT
```

The fixed code

```
case 1

first time:
time                = 2014-09-07T00:17:29
updateCurrDateAfter = 2014-09-07T00:17:30
CURR_DATE_BYTES     = Sun, 07 Sep 2014 00:17:29 GMT

next time:
time                = 2014-09-07T00:17:30
updateCurrDateAfter = 2014-09-07T00:17:30
CURR_DATE_BYTES     = Sun, 07 Sep 2014 00:17:30 GMT

case 2

first time:
time                = 2014-09-07T00:17:29.999
updateCurrDateAfter = 2014-09-07T00:17:30.000
CURR_DATE_BYTES     = Sun, 07 Sep 2014 00:17:29 GMT

next time:
time                = 2014-09-07T00:17:30.000
updateCurrDateAfter = 2014-09-07T00:17:30.000
CURR_DATE_BYTES     = Sun, 07 Sep 2014 00:17:30 GMT
```