### PR TITLE
Allow optional mutual TLS

### DIFF
--- a/rapidoid-commons/src/main/resources/built-in-config.yml
+++ b/rapidoid-commons/src/main/resources/built-in-config.yml
@@ -100,6 +100,7 @@ log:
 tls:
   selfSigned: true
   needClientAuth: false
+  wantClientAuth: false
   enabled: false
   keystore: ''
   keystorePassword: ''

--- a/rapidoid-commons/src/main/resources/built-in-config.yml
+++ b/rapidoid-commons/src/main/resources/built-in-config.yml
@@ -99,6 +99,7 @@ log:
 
 tls:
   selfSigned: true
+  needClientAuth: true
   enabled: false
   keystore: ''
   keystorePassword: ''

--- a/rapidoid-commons/src/main/resources/built-in-config.yml
+++ b/rapidoid-commons/src/main/resources/built-in-config.yml
@@ -99,7 +99,7 @@ log:
 
 tls:
   selfSigned: true
-  needClientAuth: true
+  needClientAuth: false
   enabled: false
   keystore: ''
   keystorePassword: ''

--- a/rapidoid-integration-tests/src/test/resources/test-results/ConfigurationTest/testBuiltInConfig/root
+++ b/rapidoid-integration-tests/src/test/resources/test-results/ConfigurationTest/testBuiltInConfig/root
@@ -106,6 +106,7 @@
   },
   "tls" : {
     "selfSigned" : true,
+    "needClientAuth" : false,
     "enabled" : false,
     "keystore" : "",
     "keystorePassword" : "",

--- a/rapidoid-integration-tests/src/test/resources/test-results/ConfigurationTest/testBuiltInConfig/root
+++ b/rapidoid-integration-tests/src/test/resources/test-results/ConfigurationTest/testBuiltInConfig/root
@@ -107,6 +107,7 @@
   "tls" : {
     "selfSigned" : true,
     "needClientAuth" : false,
+    "wantClientAuth" : false,
     "enabled" : false,
     "keystore" : "",
     "keystorePassword" : "",

--- a/rapidoid-integration-tests/src/test/resources/test-results/ConfigurationTest/testMySqlProfile/root
+++ b/rapidoid-integration-tests/src/test/resources/test-results/ConfigurationTest/testMySqlProfile/root
@@ -108,6 +108,7 @@
   },
   "tls" : {
     "selfSigned" : true,
+    "needClientAuth" : false,
     "enabled" : false,
     "keystore" : "",
     "keystorePassword" : "",

--- a/rapidoid-integration-tests/src/test/resources/test-results/ConfigurationTest/testMySqlProfile/root
+++ b/rapidoid-integration-tests/src/test/resources/test-results/ConfigurationTest/testMySqlProfile/root
@@ -109,6 +109,7 @@
   "tls" : {
     "selfSigned" : true,
     "needClientAuth" : false,
+    "wantClientAuth" : false,
     "enabled" : false,
     "keystore" : "",
     "keystorePassword" : "",

--- a/rapidoid-integration-tests/src/test/resources/test-results/ConfigurationTest/testPostgresProfile/root
+++ b/rapidoid-integration-tests/src/test/resources/test-results/ConfigurationTest/testPostgresProfile/root
@@ -108,6 +108,7 @@
   },
   "tls" : {
     "selfSigned" : true,
+    "needClientAuth" : false,
     "enabled" : false,
     "keystore" : "",
     "keystorePassword" : "",

--- a/rapidoid-integration-tests/src/test/resources/test-results/ConfigurationTest/testPostgresProfile/root
+++ b/rapidoid-integration-tests/src/test/resources/test-results/ConfigurationTest/testPostgresProfile/root
@@ -109,6 +109,7 @@
   "tls" : {
     "selfSigned" : true,
     "needClientAuth" : false,
+    "wantClientAuth" : false,
     "enabled" : false,
     "keystore" : "",
     "keystorePassword" : "",

--- a/rapidoid-networking/src/main/java/org/rapidoid/net/ServerBuilder.java
+++ b/rapidoid-networking/src/main/java/org/rapidoid/net/ServerBuilder.java
@@ -143,7 +143,7 @@ public class ServerBuilder extends RapidoidThing {
 	public synchronized Server build() {
 		U.must(!built, "This builder was already used! Please instantiate a new one!");
 		built = true;
-		return new RapidoidServerLoop(netParams, tlsParams.buildTLSContext());
+		return new RapidoidServerLoop(netParams, tlsParams);
 	}
 
 }

--- a/rapidoid-networking/src/main/java/org/rapidoid/net/ServerBuilder.java
+++ b/rapidoid-networking/src/main/java/org/rapidoid/net/ServerBuilder.java
@@ -135,6 +135,11 @@ public class ServerBuilder extends RapidoidThing {
 		return this;
 	}
 
+	public ServerBuilder needClientAuth(boolean needClientAuth) {
+		tlsParams.needClientAuth(needClientAuth);
+		return this;
+	}
+
 	public ServerBuilder tlsContext(SSLContext tlsContext) {
 		tlsParams.tlsContext(tlsContext);
 		return this;

--- a/rapidoid-networking/src/main/java/org/rapidoid/net/ServerBuilder.java
+++ b/rapidoid-networking/src/main/java/org/rapidoid/net/ServerBuilder.java
@@ -140,6 +140,11 @@ public class ServerBuilder extends RapidoidThing {
 		return this;
 	}
 
+	public ServerBuilder wantClientAuth(boolean wantClientAuth) {
+		tlsParams.wantClientAuth(wantClientAuth);
+		return this;
+	}
+
 	public ServerBuilder tlsContext(SSLContext tlsContext) {
 		tlsParams.tlsContext(tlsContext);
 		return this;

--- a/rapidoid-networking/src/main/java/org/rapidoid/net/TCPClientBuilder.java
+++ b/rapidoid-networking/src/main/java/org/rapidoid/net/TCPClientBuilder.java
@@ -157,7 +157,7 @@ public class TCPClientBuilder extends RapidoidThing {
 	public synchronized TCPClient build() {
 		U.must(!built, "This builder was already used! Please instantiate a new one!");
 		built = true;
-		return new RapidoidClientLoop(netParams, reconnecting, connections, tlsParams.buildTLSContext());
+		return new RapidoidClientLoop(netParams, reconnecting, connections, tlsParams);
 	}
 
 }

--- a/rapidoid-networking/src/main/java/org/rapidoid/net/TLSParams.java
+++ b/rapidoid-networking/src/main/java/org/rapidoid/net/TLSParams.java
@@ -23,6 +23,7 @@ package org.rapidoid.net;
 import org.rapidoid.RapidoidThing;
 import org.rapidoid.config.Conf;
 import org.rapidoid.net.tls.TLSUtil;
+import org.rapidoid.u.U;
 import org.rapidoid.util.MscOpts;
 
 import javax.net.ssl.SSLContext;
@@ -47,6 +48,11 @@ public class TLSParams extends RapidoidThing {
 	private volatile SSLContext tlsContext;
 
 	private volatile boolean needClientAuth = Conf.TLS.is("needClientAuth");
+	private volatile boolean wantClientAuth = Conf.TLS.is("wantClientAuth");
+
+	public TLSParams() {
+		U.must(!(needClientAuth && wantClientAuth),"Both needClientAuth and wantClientAuth cannot be true!");
+	}
 
 	public boolean tls() {
 		return tls;
@@ -115,8 +121,25 @@ public class TLSParams extends RapidoidThing {
 		return needClientAuth;
 	}
 
+	/*
+	 * Similar to javax.net.ssl.SSLParameters#setNeedClientAuth
+	 */
 	public TLSParams needClientAuth(boolean needClientAuth) {
 		this.needClientAuth = needClientAuth;
+		this.wantClientAuth = false;
+		return this;
+	}
+
+	public boolean wantClientAuth() {
+		return wantClientAuth;
+	}
+
+	/*
+	* Similar to javax.net.ssl.SSLParameters#setWantClientAuth
+	*/
+	public TLSParams wantClientAuth(boolean wantClientAuth) {
+		this.wantClientAuth = wantClientAuth;
+		this.needClientAuth = false;
 		return this;
 	}
 

--- a/rapidoid-networking/src/main/java/org/rapidoid/net/TLSParams.java
+++ b/rapidoid-networking/src/main/java/org/rapidoid/net/TLSParams.java
@@ -46,6 +46,8 @@ public class TLSParams extends RapidoidThing {
 
 	private volatile SSLContext tlsContext;
 
+	private volatile boolean needClientAuth = Conf.TLS.is("needClientAuth");
+
 	public boolean tls() {
 		return tls;
 	}
@@ -106,6 +108,15 @@ public class TLSParams extends RapidoidThing {
 
 	public TLSParams selfSignedTLS(boolean selfSignedTLS) {
 		this.selfSignedTLS = selfSignedTLS;
+		return this;
+	}
+
+	public boolean needClientAuth() {
+		return needClientAuth;
+	}
+
+	public TLSParams needClientAuth(boolean needClientAuth) {
+		this.needClientAuth = needClientAuth;
 		return this;
 	}
 

--- a/rapidoid-networking/src/main/java/org/rapidoid/net/impl/ExtendedWorker.java
+++ b/rapidoid-networking/src/main/java/org/rapidoid/net/impl/ExtendedWorker.java
@@ -101,7 +101,7 @@ public class ExtendedWorker extends AbstractEventLoop<ExtendedWorker> implements
 
 	private final SSLContext sslContext;
 
-	private final boolean needClientAuth;
+	private final TLSParams tlsParams;
 
 	private final StatsMeasure dataIn;
 
@@ -130,7 +130,7 @@ public class ExtendedWorker extends AbstractEventLoop<ExtendedWorker> implements
 		this.serverProtocol = net.protocol();
 		this.helper = helper;
 		this.sslContext = tlsParams.buildTLSContext();
-		this.needClientAuth = tlsParams.needClientAuth();
+		this.tlsParams = tlsParams;
 
 		this.maxPipeline = net.maxPipeline();
 
@@ -692,7 +692,7 @@ public class ExtendedWorker extends AbstractEventLoop<ExtendedWorker> implements
 
 	@Override
 	public RapidoidConnection newConnection(boolean client) {
-		RapidoidConnection conn = new RapidoidConnection(ExtendedWorker.this, bufs, this.needClientAuth);
+		RapidoidConnection conn = new RapidoidConnection(ExtendedWorker.this, bufs, this.tlsParams);
 		allConnections.add(conn);
 		return conn;
 	}

--- a/rapidoid-networking/src/main/java/org/rapidoid/net/impl/ExtendedWorker.java
+++ b/rapidoid-networking/src/main/java/org/rapidoid/net/impl/ExtendedWorker.java
@@ -36,6 +36,7 @@ import org.rapidoid.insight.StatsMeasure;
 import org.rapidoid.log.Log;
 import org.rapidoid.net.NetworkingParams;
 import org.rapidoid.net.Protocol;
+import org.rapidoid.net.TLSParams;
 import org.rapidoid.pool.Pool;
 import org.rapidoid.pool.Pools;
 import org.rapidoid.u.U;
@@ -100,6 +101,8 @@ public class ExtendedWorker extends AbstractEventLoop<ExtendedWorker> implements
 
 	private final SSLContext sslContext;
 
+	private final boolean needClientAuth;
+
 	private final StatsMeasure dataIn;
 
 	private final StatsMeasure dataOut;
@@ -115,7 +118,7 @@ public class ExtendedWorker extends AbstractEventLoop<ExtendedWorker> implements
 		}
 	}
 
-	public ExtendedWorker(String name, RapidoidHelper helper, NetworkingParams net, SSLContext sslContext) {
+	public ExtendedWorker(String name, RapidoidHelper helper, NetworkingParams net, TLSParams tlsParams) {
 
 		super(name);
 
@@ -126,7 +129,8 @@ public class ExtendedWorker extends AbstractEventLoop<ExtendedWorker> implements
 
 		this.serverProtocol = net.protocol();
 		this.helper = helper;
-		this.sslContext = sslContext;
+		this.sslContext = tlsParams.buildTLSContext();
+		this.needClientAuth = tlsParams.needClientAuth();
 
 		this.maxPipeline = net.maxPipeline();
 
@@ -688,7 +692,7 @@ public class ExtendedWorker extends AbstractEventLoop<ExtendedWorker> implements
 
 	@Override
 	public RapidoidConnection newConnection(boolean client) {
-		RapidoidConnection conn = new RapidoidConnection(ExtendedWorker.this, bufs);
+		RapidoidConnection conn = new RapidoidConnection(ExtendedWorker.this, bufs, this.needClientAuth);
 		allConnections.add(conn);
 		return conn;
 	}

--- a/rapidoid-networking/src/main/java/org/rapidoid/net/impl/RapidoidClientLoop.java
+++ b/rapidoid-networking/src/main/java/org/rapidoid/net/impl/RapidoidClientLoop.java
@@ -57,6 +57,7 @@ public class RapidoidClientLoop extends AbstractEventLoop<TCPClient> implements 
 		this.connections = connections;
 		this.tlsParams = tlsParams;
 		this.tlsParams.needClientAuth(false);		// set to false as client need not have this set to true.
+		this.tlsParams.wantClientAuth(false);		// set to false as client need not have this set to true.
 	}
 
 	@Override

--- a/rapidoid-networking/src/main/java/org/rapidoid/net/impl/RapidoidClientLoop.java
+++ b/rapidoid-networking/src/main/java/org/rapidoid/net/impl/RapidoidClientLoop.java
@@ -23,14 +23,10 @@ package org.rapidoid.net.impl;
 import org.rapidoid.annotation.Authors;
 import org.rapidoid.annotation.Since;
 import org.rapidoid.cls.Cls;
-import org.rapidoid.net.NetworkingParams;
-import org.rapidoid.net.Protocol;
-import org.rapidoid.net.TCPClient;
-import org.rapidoid.net.TCPClientInfo;
+import org.rapidoid.net.*;
 import org.rapidoid.net.abstracts.ChannelHolder;
 import org.rapidoid.u.U;
 
-import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.channels.SocketChannel;
@@ -46,20 +42,21 @@ public class RapidoidClientLoop extends AbstractEventLoop<TCPClient> implements 
 
 	private final boolean autoReconnect;
 
-	private final SSLContext sslContext;
+	private final TLSParams tlsParams;
 
 	private volatile ExtendedWorker[] ioWorkers;
 
 	// round-robin workers for new connections
 	private int currentWorkerInd = 0;
 
-	public RapidoidClientLoop(NetworkingParams net, boolean autoReconnect, int connections, SSLContext sslContext) {
+	public RapidoidClientLoop(NetworkingParams net, boolean autoReconnect, int connections, TLSParams tlsParams) {
 		super("client");
 
 		this.net = net;
 		this.autoReconnect = autoReconnect;
 		this.connections = connections;
-		this.sslContext = sslContext;
+		this.tlsParams = tlsParams;
+		this.tlsParams.needClientAuth(false);		// set to false as client need not have this set to true.
 	}
 
 	@Override
@@ -77,7 +74,7 @@ public class RapidoidClientLoop extends AbstractEventLoop<TCPClient> implements 
 		for (int i = 0; i < ioWorkers.length; i++) {
 			RapidoidHelper helper = Cls.newInstance(net.helperClass(), net.exchangeClass());
 			String workerName = "client" + (i + 1);
-			ioWorkers[i] = new ExtendedWorker(workerName, helper, net, sslContext);
+			ioWorkers[i] = new ExtendedWorker(workerName, helper, net, tlsParams);
 
 			new Thread(ioWorkers[i], workerName).start();
 		}

--- a/rapidoid-networking/src/main/java/org/rapidoid/net/impl/RapidoidConnection.java
+++ b/rapidoid-networking/src/main/java/org/rapidoid/net/impl/RapidoidConnection.java
@@ -124,11 +124,11 @@ public class RapidoidConnection extends RapidoidThing implements Resetable, Chan
 
 	private volatile boolean autoReconnect;
 
-	public RapidoidConnection(NetWorker worker, BufGroup bufs) {
+	public RapidoidConnection(NetWorker worker, BufGroup bufs, boolean needClientAuth) {
 		this.worker = worker;
 
 		this.hasTLS = worker.sslContext() != null;
-		this.tls = hasTLS ? new RapidoidTLS(worker.sslContext(), this) : null;
+		this.tls = hasTLS ? new RapidoidTLS(worker.sslContext(), this, needClientAuth) : null;
 
 		this.input = bufs.newBuf("input#" + serialN);
 		this.output = bufs.newBuf("output#" + serialN);

--- a/rapidoid-networking/src/main/java/org/rapidoid/net/impl/RapidoidConnection.java
+++ b/rapidoid-networking/src/main/java/org/rapidoid/net/impl/RapidoidConnection.java
@@ -32,6 +32,7 @@ import org.rapidoid.job.Jobs;
 import org.rapidoid.log.Log;
 import org.rapidoid.net.AsyncLogic;
 import org.rapidoid.net.Protocol;
+import org.rapidoid.net.TLSParams;
 import org.rapidoid.net.abstracts.Channel;
 import org.rapidoid.net.abstracts.ChannelHolder;
 import org.rapidoid.net.abstracts.IRequest;
@@ -124,11 +125,11 @@ public class RapidoidConnection extends RapidoidThing implements Resetable, Chan
 
 	private volatile boolean autoReconnect;
 
-	public RapidoidConnection(NetWorker worker, BufGroup bufs, boolean needClientAuth) {
+	public RapidoidConnection(NetWorker worker, BufGroup bufs, TLSParams tlsParams) {
 		this.worker = worker;
 
 		this.hasTLS = worker.sslContext() != null;
-		this.tls = hasTLS ? new RapidoidTLS(worker.sslContext(), this, needClientAuth) : null;
+		this.tls = hasTLS ? new RapidoidTLS(worker.sslContext(), this, tlsParams) : null;
 
 		this.input = bufs.newBuf("input#" + serialN);
 		this.output = bufs.newBuf("output#" + serialN);

--- a/rapidoid-networking/src/main/java/org/rapidoid/net/impl/RapidoidServerLoop.java
+++ b/rapidoid-networking/src/main/java/org/rapidoid/net/impl/RapidoidServerLoop.java
@@ -24,14 +24,10 @@ import org.rapidoid.annotation.Authors;
 import org.rapidoid.annotation.Since;
 import org.rapidoid.commons.Rnd;
 import org.rapidoid.log.Log;
-import org.rapidoid.net.NetworkingParams;
-import org.rapidoid.net.Protocol;
-import org.rapidoid.net.Server;
-import org.rapidoid.net.TCPServerInfo;
+import org.rapidoid.net.*;
 import org.rapidoid.thread.RapidoidThread;
 import org.rapidoid.u.U;
 
-import javax.net.ssl.SSLContext;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
@@ -46,7 +42,7 @@ public class RapidoidServerLoop extends AbstractLoop<Server> implements Server, 
 	private static final int MAX_PENDING_CONNECTIONS = 16 * 1024;
 
 	private final NetworkingParams net;
-	private final SSLContext sslContext;
+	private final TLSParams tlsParams;
 
 	private final Selector selector;
 	private ServerSocketChannel serverSocketChannel;
@@ -55,11 +51,11 @@ public class RapidoidServerLoop extends AbstractLoop<Server> implements Server, 
 
 	private RapidoidWorker currentWorker;
 
-	public RapidoidServerLoop(NetworkingParams net, SSLContext sslContext) {
+	public RapidoidServerLoop(NetworkingParams net, TLSParams tlsParams) {
 		super("server");
 
 		this.net = net;
-		this.sslContext = sslContext;
+		this.tlsParams = tlsParams;
 
 		try {
 			this.selector = Selector.open();
@@ -127,7 +123,7 @@ public class RapidoidServerLoop extends AbstractLoop<Server> implements Server, 
 
 		for (int i = 0; i < ioWorkers.length; i++) {
 
-			RapidoidWorkerThread workerThread = new RapidoidWorkerThread(i, net, sslContext);
+			RapidoidWorkerThread workerThread = new RapidoidWorkerThread(i, net, tlsParams);
 
 			workerThread.start();
 

--- a/rapidoid-networking/src/main/java/org/rapidoid/net/impl/RapidoidWorker.java
+++ b/rapidoid-networking/src/main/java/org/rapidoid/net/impl/RapidoidWorker.java
@@ -87,7 +87,7 @@ public class RapidoidWorker extends AbstractEventLoop<RapidoidWorker> implements
 
 	private final SSLContext sslContext;
 
-	private final boolean needClientAuth;
+	private final TLSParams tlsParams;
 
 	RapidoidWorker next;
 
@@ -113,7 +113,7 @@ public class RapidoidWorker extends AbstractEventLoop<RapidoidWorker> implements
 		this.serverProtocol = net.protocol();
 		this.helper = helper;
 		this.sslContext = tlsParams.buildTLSContext();
-		this.needClientAuth = tlsParams.needClientAuth();
+		this.tlsParams = tlsParams;
 
 		this.maxPipeline = net.maxPipeline();
 
@@ -553,7 +553,7 @@ public class RapidoidWorker extends AbstractEventLoop<RapidoidWorker> implements
 	@Override
 	public RapidoidConnection newConnection(boolean client) {
 		U.must(!client, "Client connections are not supported by this worker!");
-		RapidoidConnection conn = new RapidoidConnection(RapidoidWorker.this, bufs, this.needClientAuth);
+		RapidoidConnection conn = new RapidoidConnection(RapidoidWorker.this, bufs, this.tlsParams);
 		allConnections.add(conn);
 		return conn;
 	}

--- a/rapidoid-networking/src/main/java/org/rapidoid/net/impl/RapidoidWorker.java
+++ b/rapidoid-networking/src/main/java/org/rapidoid/net/impl/RapidoidWorker.java
@@ -34,6 +34,7 @@ import org.rapidoid.expire.Expire;
 import org.rapidoid.log.Log;
 import org.rapidoid.net.NetworkingParams;
 import org.rapidoid.net.Protocol;
+import org.rapidoid.net.TLSParams;
 import org.rapidoid.pool.Pool;
 import org.rapidoid.pool.Pools;
 import org.rapidoid.u.U;
@@ -86,6 +87,8 @@ public class RapidoidWorker extends AbstractEventLoop<RapidoidWorker> implements
 
 	private final SSLContext sslContext;
 
+	private final boolean needClientAuth;
+
 	RapidoidWorker next;
 
 	static {
@@ -99,7 +102,7 @@ public class RapidoidWorker extends AbstractEventLoop<RapidoidWorker> implements
 		}
 	}
 
-	public RapidoidWorker(String name, final RapidoidHelper helper, NetworkingParams net, SSLContext sslContext) {
+	public RapidoidWorker(String name, final RapidoidHelper helper, NetworkingParams net, TLSParams tlsParams) {
 
 		super(name);
 
@@ -109,7 +112,8 @@ public class RapidoidWorker extends AbstractEventLoop<RapidoidWorker> implements
 
 		this.serverProtocol = net.protocol();
 		this.helper = helper;
-		this.sslContext = sslContext;
+		this.sslContext = tlsParams.buildTLSContext();
+		this.needClientAuth = tlsParams.needClientAuth();
 
 		this.maxPipeline = net.maxPipeline();
 
@@ -549,7 +553,7 @@ public class RapidoidWorker extends AbstractEventLoop<RapidoidWorker> implements
 	@Override
 	public RapidoidConnection newConnection(boolean client) {
 		U.must(!client, "Client connections are not supported by this worker!");
-		RapidoidConnection conn = new RapidoidConnection(RapidoidWorker.this, bufs);
+		RapidoidConnection conn = new RapidoidConnection(RapidoidWorker.this, bufs, this.needClientAuth);
 		allConnections.add(conn);
 		return conn;
 	}

--- a/rapidoid-networking/src/main/java/org/rapidoid/net/impl/RapidoidWorkerThread.java
+++ b/rapidoid-networking/src/main/java/org/rapidoid/net/impl/RapidoidWorkerThread.java
@@ -24,10 +24,9 @@ import org.rapidoid.annotation.Authors;
 import org.rapidoid.annotation.Since;
 import org.rapidoid.cls.Cls;
 import org.rapidoid.net.NetworkingParams;
+import org.rapidoid.net.TLSParams;
 import org.rapidoid.thread.RapidoidThread;
 import org.rapidoid.u.U;
-
-import javax.net.ssl.SSLContext;
 
 @Authors("Nikolche Mihajlovski")
 @Since("4.1.0")
@@ -35,16 +34,16 @@ public class RapidoidWorkerThread extends RapidoidThread {
 
 	private final int workerIndex;
 	private final NetworkingParams net;
-	private final SSLContext sslContext;
+	private final TLSParams tlsParams;
 
 	private volatile RapidoidWorker worker;
 
-	RapidoidWorkerThread(int workerIndex, NetworkingParams net, SSLContext sslContext) {
+	RapidoidWorkerThread(int workerIndex, NetworkingParams net, TLSParams tlsParams) {
 		super("server" + (workerIndex + 1));
 
 		this.workerIndex = workerIndex;
 		this.net = net;
-		this.sslContext = sslContext;
+		this.tlsParams = tlsParams;
 	}
 
 	@Override
@@ -52,7 +51,7 @@ public class RapidoidWorkerThread extends RapidoidThread {
 		RapidoidHelper helper = Cls.newInstance(net.helperClass(), net.exchangeClass());
 		helper.requestIdGen = workerIndex; // to generate UNIQUE request ID (+= MAX_IO_WORKERS)
 
-		worker = new RapidoidWorker("server" + (workerIndex + 1), helper, net, sslContext);
+		worker = new RapidoidWorker("server" + (workerIndex + 1), helper, net, tlsParams);
 
 		worker.run();
 	}

--- a/rapidoid-networking/src/main/java/org/rapidoid/net/tls/RapidoidTLS.java
+++ b/rapidoid-networking/src/main/java/org/rapidoid/net/tls/RapidoidTLS.java
@@ -26,6 +26,7 @@ import org.rapidoid.annotation.Since;
 import org.rapidoid.buffer.BufUtil;
 import org.rapidoid.commons.Err;
 import org.rapidoid.log.Log;
+import org.rapidoid.net.TLSParams;
 import org.rapidoid.net.impl.RapidoidConnection;
 import org.rapidoid.u.U;
 import org.rapidoid.util.Msc;
@@ -40,7 +41,7 @@ public class RapidoidTLS extends RapidoidThing {
 	private static boolean debugging = false;
 
 	private final SSLContext sslContext;
-	private final boolean needClientAuth;
+	private final TLSParams tlsParams;
 	private final RapidoidConnection conn;
 
 	private volatile SSLEngine engine;
@@ -49,10 +50,10 @@ public class RapidoidTLS extends RapidoidThing {
 	public final ByteBuffer netIn;
 	final ByteBuffer netOut;
 
-	public RapidoidTLS(SSLContext sslContext, RapidoidConnection conn, boolean needClientAuth) {
+	public RapidoidTLS(SSLContext sslContext, RapidoidConnection conn, TLSParams tlsParams) {
 
 		this.sslContext = sslContext;
-		this.needClientAuth = needClientAuth;
+		this.tlsParams = tlsParams;
 		this.conn = conn;
 		this.engine = createServerEngine();
 
@@ -69,7 +70,8 @@ public class RapidoidTLS extends RapidoidThing {
 	private SSLEngine createServerEngine() {
 		SSLEngine engine = sslContext.createSSLEngine();
 		engine.setUseClientMode(false);
-		engine.setNeedClientAuth(needClientAuth);
+		engine.setNeedClientAuth(tlsParams.needClientAuth());
+		engine.setWantClientAuth(tlsParams.wantClientAuth());
 		return engine;
 	}
 

--- a/rapidoid-networking/src/main/java/org/rapidoid/net/tls/RapidoidTLS.java
+++ b/rapidoid-networking/src/main/java/org/rapidoid/net/tls/RapidoidTLS.java
@@ -70,8 +70,8 @@ public class RapidoidTLS extends RapidoidThing {
 	private SSLEngine createServerEngine() {
 		SSLEngine engine = sslContext.createSSLEngine();
 		engine.setUseClientMode(false);
-		engine.setNeedClientAuth(tlsParams.needClientAuth());
-		engine.setWantClientAuth(tlsParams.wantClientAuth());
+		if(tlsParams.needClientAuth()) engine.setNeedClientAuth(tlsParams.needClientAuth());
+		if(tlsParams.wantClientAuth()) engine.setWantClientAuth(tlsParams.wantClientAuth());
 		return engine;
 	}
 

--- a/rapidoid-networking/src/main/java/org/rapidoid/net/tls/RapidoidTLS.java
+++ b/rapidoid-networking/src/main/java/org/rapidoid/net/tls/RapidoidTLS.java
@@ -40,6 +40,7 @@ public class RapidoidTLS extends RapidoidThing {
 	private static boolean debugging = false;
 
 	private final SSLContext sslContext;
+	private final boolean needClientAuth;
 	private final RapidoidConnection conn;
 
 	private volatile SSLEngine engine;
@@ -48,9 +49,10 @@ public class RapidoidTLS extends RapidoidThing {
 	public final ByteBuffer netIn;
 	final ByteBuffer netOut;
 
-	public RapidoidTLS(SSLContext sslContext, RapidoidConnection conn) {
+	public RapidoidTLS(SSLContext sslContext, RapidoidConnection conn, boolean needClientAuth) {
 
 		this.sslContext = sslContext;
+		this.needClientAuth = needClientAuth;
 		this.conn = conn;
 		this.engine = createServerEngine();
 
@@ -67,6 +69,7 @@ public class RapidoidTLS extends RapidoidThing {
 	private SSLEngine createServerEngine() {
 		SSLEngine engine = sslContext.createSSLEngine();
 		engine.setUseClientMode(false);
+		engine.setNeedClientAuth(needClientAuth);
 		return engine;
 	}
 

--- a/rapidoid-networking/src/test/java/org/rapidoid/net/TLSParamsTest.java
+++ b/rapidoid-networking/src/test/java/org/rapidoid/net/TLSParamsTest.java
@@ -1,0 +1,39 @@
+package org.rapidoid.net;
+
+import org.junit.jupiter.api.Test;
+import org.rapidoid.NetTestCommons;
+import org.rapidoid.config.Conf;
+
+public class TLSParamsTest extends NetTestCommons {
+    @Test
+    public void testInitialization() {
+        Conf.TLS.set("needClientAuth", true);
+        Conf.TLS.set("wantClientAuth", true);
+
+        boolean errorCaught = false;
+
+        try {
+            new TLSParams();
+        } catch(Exception e) {
+            errorCaught = true;
+        }
+        isTrue(errorCaught);
+    }
+
+    @Test
+    public void testSetter() {
+        TLSParams tlsParams = new TLSParams();
+
+        tlsParams.wantClientAuth(true);
+        isTrue(tlsParams.wantClientAuth());
+        isFalse(tlsParams.needClientAuth());
+
+        tlsParams.needClientAuth(true);
+        isTrue(tlsParams.needClientAuth());
+        isFalse(tlsParams.wantClientAuth());
+
+        tlsParams.wantClientAuth(true);
+        isTrue(tlsParams.wantClientAuth());
+        isFalse(tlsParams.needClientAuth());
+    }
+}

--- a/rapidoid-networking/src/test/java/org/rapidoid/net/tls/RapidoidTLSTest.java
+++ b/rapidoid-networking/src/test/java/org/rapidoid/net/tls/RapidoidTLSTest.java
@@ -1,0 +1,50 @@
+package org.rapidoid.net.tls;
+
+
+import org.junit.jupiter.api.Test;
+import org.rapidoid.NetTestCommons;
+import org.rapidoid.net.TLSParams;
+
+import javax.net.ssl.SSLContext;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+public class RapidoidTLSTest extends NetTestCommons {
+    @Test
+    public void testNeedClientAuth() throws NoSuchAlgorithmException, KeyManagementException {
+        SSLContext context = SSLContext.getDefault();
+
+        TLSParams tlsParams = new TLSParams();
+        tlsParams.needClientAuth(true);
+
+        RapidoidTLS tls = new RapidoidTLS(context, null, tlsParams);
+
+        isTrue(tls.engine().getNeedClientAuth());
+        isFalse(tls.engine().getWantClientAuth());
+    }
+
+    @Test
+    public void testWantClientAuth() throws NoSuchAlgorithmException, KeyManagementException {
+        SSLContext context = SSLContext.getDefault();
+
+        TLSParams tlsParams = new TLSParams();
+        tlsParams.wantClientAuth(true);
+
+        RapidoidTLS tls = new RapidoidTLS(context, null, tlsParams);
+
+        isTrue(tls.engine().getWantClientAuth());
+        isFalse(tls.engine().getNeedClientAuth());
+    }
+
+    @Test
+    public void testNoClientAuth() throws NoSuchAlgorithmException, KeyManagementException {
+        SSLContext context = SSLContext.getDefault();
+
+        TLSParams tlsParams = new TLSParams();
+
+        RapidoidTLS tls = new RapidoidTLS(context, null, tlsParams);
+
+        isFalse(tls.engine().getNeedClientAuth());
+        isFalse(tls.engine().getWantClientAuth());
+    }
+}


### PR DESCRIPTION
Creating settings `needClientAuth` and `wantClientAuth` in TLSParams that allows setting of client authentication by the SSLEngine. This would facilitate using rapidoid for situations where client authentication can be used to achieve mutual TLS connection.