### PR TITLE
Dynamically adjust the number of Forked VM based on the number of CPU cores

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
                 <configuration>
                     <argLine>${jdk9.modules} -Xms512m -Xmx1024m -Dfile.encoding=${project.build.sourceEncoding}
                     </argLine>
+                	<forkCount>1.5C</forkCount>
                 </configuration>
                 <dependencies>
                     <dependency>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
