### PR TITLE
Improve performance in the Test phase

### DIFF
--- a/examples/dsl-json-integration/pom.xml
+++ b/examples/dsl-json-integration/pom.xml
@@ -65,7 +65,7 @@
                 <version>2.19.1</version>
                 <configuration>
                     <argLine>-Xms512m -Xmx1024m</argLine>
-                    <forkCount>1</forkCount>
+                    <forkCount>1.5C</forkCount>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/examples/getting-started/pom.xml
+++ b/examples/getting-started/pom.xml
@@ -60,7 +60,7 @@
                 <version>2.19.1</version>
                 <configuration>
                     <argLine>-Xms512m -Xmx1024m</argLine>
-                    <forkCount>1</forkCount>
+                    <forkCount>1.5C</forkCount>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/examples/hello-world/pom.xml
+++ b/examples/hello-world/pom.xml
@@ -60,7 +60,7 @@
                 <version>2.19.1</version>
                 <configuration>
                     <argLine>-Xms512m -Xmx1024m</argLine>
-                    <forkCount>1</forkCount>
+                    <forkCount>1.5C</forkCount>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/examples/rest-api/pom.xml
+++ b/examples/rest-api/pom.xml
@@ -60,7 +60,7 @@
                 <version>2.19.1</version>
                 <configuration>
                     <argLine>-Xms512m -Xmx1024m</argLine>
-                    <forkCount>1</forkCount>
+                    <forkCount>1.5C</forkCount>
                 </configuration>
                 <dependencies>
                     <dependency>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
