### PR TITLE
fix(sec): upgrade org.hibernate.validator:hibernate-validator to 6.1.3.Final

### DIFF
--- a/rapidoid-rest/pom.xml
+++ b/rapidoid-rest/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>6.0.2.Final</version>
+            <version>6.1.3.Final</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate.validator</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.hibernate.validator:hibernate-validator 6.0.2.Final
- [CVE-2019-10219](https://www.oscs1024.com/hd/CVE-2019-10219)


### What did I do？
Upgrade org.hibernate.validator:hibernate-validator from 6.0.2.Final to 6.1.3.Final for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS